### PR TITLE
feat: add .NET 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
                   dotnet-version: |
                     8.0.x
                     9.0.x
+                    10.0.x
 
             - name: dotnet build
               run: dotnet build solrevdev.seedfolder.sln --configuration Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Template files are stored as embedded resources in `src/Data/` and copied to new
 - `SafeNameForFileSystem()` - Removes invalid filesystem characters from folder names
 
 ## Multi-Target Framework Support
-The project targets .NET 8.0 (LTS) and 9.0 (STS) to support current and modern .NET versions. .NET 8 provides long-term support until November 2026, while .NET 9 offers the latest features with 18-month support.
+The project targets .NET 8.0 (LTS), 9.0 (STS), and 10.0 (LTS) to support current and modern .NET versions. .NET 8 provides long-term support until November 2026, .NET 9 offers the latest features with 18-month support, and .NET 10 is the latest LTS release providing long-term support until November 2028.
 
 ## CI/CD
 GitHub Actions workflow builds, packs, and publishes to NuGet on pushes to master branch. Version is controlled by the `<Version>` property in the .csproj file.

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ git commit -m "Initial commit"
 
 ## Requirements
 
-This tool requires **.NET 8.0 or .NET 9.0 SDK** to be installed on your system.
+This tool requires **.NET 8.0, .NET 9.0, or .NET 10.0 SDK** to be installed on your system.
 
 - **Supported Platforms**: Windows, macOS, Linux
 - **Runtime**: .NET 8.0 or later
@@ -473,18 +473,18 @@ dotnet tool uninstall --global solrevdev.seedfolder
 ## Run directly during development
 
 # Interactive mode
-dotnet run --project src/solrevdev.seedfolder.csproj --framework net9.0
+dotnet run --project src/solrevdev.seedfolder.csproj --framework net10.0
 
 ## With arguments
 
 # Show the application's version (pass `--version` to the app via `--`)
-dotnet run --project src/solrevdev.seedfolder.csproj --framework net9.0 -- --version
+dotnet run --project src/solrevdev.seedfolder.csproj --framework net10.0 -- --version
 
 # Show the application's help text (pass `--help` to the app via `--`)
-dotnet run --project src/solrevdev.seedfolder.csproj --framework net9.0 -- --help
+dotnet run --project src/solrevdev.seedfolder.csproj --framework net10.0 -- --help
 
 # Create a Node template project using the app (arguments after `--` are for the app)
-dotnet run --project src/solrevdev.seedfolder.csproj --framework net9.0 -- --template node myapp
+dotnet run --project src/solrevdev.seedfolder.csproj --framework net10.0 -- --template node myapp
 
 # If you omit `--` and run `dotnet run --project ... --help`, the .NET CLI help will be shown.
 ```

--- a/src/solrevdev.seedfolder.csproj
+++ b/src/solrevdev.seedfolder.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>seedfolder</ToolCommandName>
     <PackageOutputPath>./nupkg</PackageOutputPath>
     <NoDefaultExcludes>true</NoDefaultExcludes>
-    <Version>1.3.3</Version>
+    <Version>1.4.0</Version>
     <Title>solrevdev.seedfolder</Title>
     <Description>.NET Core Global Tool that creates a folder and copies dotfiles into it therefore seeding a folder.</Description>
     <PackageDescription>.NET Core Global Tool that creates a folder and copies dotfiles into it therefore seeding a folder.</PackageDescription>


### PR DESCRIPTION
## Summary
This PR adds support for .NET 10 while maintaining full backward compatibility with .NET 8 and .NET 9.

## Changes
- ✅ Added `net10.0` to `TargetFrameworks` in .csproj (now targets: `net8.0;net9.0;net10.0`)
- ✅ Updated CI workflow to install .NET 10.0.x SDK
- ✅ Updated README.md to document .NET 10 support
- ✅ Updated CLAUDE.md with .NET 10 framework information
- ✅ Bumped version from 1.3.3 to 1.4.0 for NuGet release

## Testing
- ✅ Build successful for all three target frameworks (net8.0, net9.0, net10.0)
- ✅ Tested locally with .NET 10.0.100 SDK

## Framework Support
The project now targets:
- **.NET 8.0** (LTS until November 2026)
- **.NET 9.0** (STS with 18-month support)
- **.NET 10.0** (LTS until November 2028)

## Backward Compatibility
✅ **All existing SDK support maintained** - this is an additive change only. Users with .NET 8 or 9 can continue to use the tool without any changes.

## Notes
- When multiple SDKs are installed, the .NET CLI will automatically use the highest compatible SDK version
- No breaking changes
- All existing functionality preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)